### PR TITLE
Remove unused vue3-simple-alert to drop vulnerable nested sweetalert2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "animate.css": "^4.1.0",
         "sweetalert2": "^11.22.5",
-        "vue3-simple-alert": "^1.0.4",
         "vuedraggable": "^4.1.0"
       },
       "devDependencies": {
@@ -3210,24 +3209,6 @@
       "peerDependencies": {
         "vue": "^3.5.0"
       }
-    },
-    "node_modules/vue3-simple-alert": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/vue3-simple-alert/-/vue3-simple-alert-1.0.4.tgz",
-      "integrity": "sha512-AzYJr+sdPotsWvX7ykojyTxbkJBmKoPbgNGquRQd07ppkEMOTnLWvLKwqmV0Pb/Aa6nXjOlek3rMAoffTqU3TA==",
-      "license": "MIT",
-      "dependencies": {
-        "sweetalert2": "^8.18.6"
-      },
-      "peerDependencies": {
-        "vue": "3.x"
-      }
-    },
-    "node_modules/vue3-simple-alert/node_modules/sweetalert2": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-8.19.1.tgz",
-      "integrity": "sha512-EOeDLj31k1X948R6B8sMG5EhU3egbMRBNZs/cog0egIdLZ6E0R0elZrcbwiGhV50IPHO39vDUNCRmzxqwJhRag==",
-      "license": "MIT"
     },
     "node_modules/vuedraggable": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "animate.css": "^4.1.0",
     "sweetalert2": "^11.22.5",
-    "vue3-simple-alert": "^1.0.4",
     "vuedraggable": "^4.1.0"
   }
 }


### PR DESCRIPTION
Removes the unused `vue3-simple-alert` package, which transitively pulled in `sweetalert2@8.19.1` (vulnerable to [GHSA-8jh9-wqpf-q52c](https://github.com/advisories/GHSA-8jh9-wqpf-q52c), patched in 11.22.4).

The package was declared in `package.json` but never imported anywhere in the codebase — `grep -ri 'vue3-simple-alert\|VueSimpleAlert'` only matched `package.json` and `package-lock.json`.

The two components that use SweetAlert (`n01-scorer.vue`, `lose-lives.vue`) `import Swal from 'sweetalert2'` directly, which resolves to the top-level `sweetalert2@^11.0.0` — already on the patched version (11.26.25). So no runtime code was actually using the vulnerable copy; the nested v8 was dead weight in the lockfile.

After removal `npm ls sweetalert2` shows only `sweetalert2@11.26.25` and `npm audit` is clean.

Closes dependabot alert #156.
